### PR TITLE
SB-20811: add certificate data without printUri to cassandra and ES

### DIFF
--- a/all-actors/pom.xml
+++ b/all-actors/pom.xml
@@ -35,6 +35,13 @@
             <artifactId>unirest-java</artifactId>
             <version>1.4.9</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.6</version>
+        </dependency>
+
         <dependency>
             <groupId>com.typesafe.akka</groupId>
             <artifactId>akka-testkit_2.12</artifactId>

--- a/all-actors/src/main/java/org/sunbird/CertVars.java
+++ b/all-actors/src/main/java/org/sunbird/CertVars.java
@@ -29,7 +29,7 @@ public class CertVars {
             logger.error("CertVars:getPropsFromEnvs:no suitable host found for downloadUri");
             System.exit(-1);
         }
-        return "http://localhost:9001";
+        return SERVICE_BASE_URL;
     }
     public static String getDOWNLOAD_URI() {
         return DOWNLOAD_URI;

--- a/all-actors/src/main/java/org/sunbird/CertVars.java
+++ b/all-actors/src/main/java/org/sunbird/CertVars.java
@@ -29,7 +29,7 @@ public class CertVars {
             logger.error("CertVars:getPropsFromEnvs:no suitable host found for downloadUri");
             System.exit(-1);
         }
-        return SERVICE_BASE_URL;
+        return "http://localhost:9001";
     }
     public static String getDOWNLOAD_URI() {
         return DOWNLOAD_URI;

--- a/all-actors/src/main/java/org/sunbird/serviceimpl/CertsServiceImpl.java
+++ b/all-actors/src/main/java/org/sunbird/serviceimpl/CertsServiceImpl.java
@@ -6,6 +6,7 @@ import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.JsonNode;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
@@ -25,6 +26,8 @@ import org.sunbird.utilities.CertificateUtil;
 import org.sunbird.utilities.ESResponseMapper;
 
 import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.List;
@@ -221,8 +224,16 @@ public class CertsServiceImpl implements ICertService {
         if (CollectionUtils.isNotEmpty(resultList) && MapUtils.isNotEmpty(resultList.get(0))) {
             Map<String, Object> certInfo = resultList.get(0);
             try {
-                Map<String, Object> data = requestMapper.readValue((String) certInfo.get(JsonKeys.DATA), new TypeReference<Map<String, Object>>() {});
-                response.put(JsonKeys.PRINT_URI, data.get(JsonKeys.PRINT_URI));
+                String jsonUrl = (String) certInfo.get(JsonKeys.JSON_URL);
+                String printUri;
+                if (StringUtils.isEmpty(jsonUrl)) {
+                    Map<String, Object> certificate = requestMapper.readValue((String) certInfo.get(JsonKeys.DATA), new TypeReference<Map<String, Object>>() {});
+                    printUri = (String) certificate.get(JsonKeys.PRINT_URI);
+                } else {
+                    String signedJsonUrl = getJsonSignedUrl((String) certInfo.get(JsonKeys.JSON_URL));
+                    printUri = getPrintUri(signedJsonUrl);
+                }
+                response.put(JsonKeys.PRINT_URI, printUri);
             } catch (Exception e) {
                 logger.error("CertsServiceImpl:downloadV2:exception occurred:" + e);
                 throw new BaseException(IResponseMessage.INTERNAL_ERROR, getLocalizedMessage(IResponseMessage.INTERNAL_ERROR, null), ResponseCode.SERVER_ERROR.getCode());
@@ -231,6 +242,44 @@ public class CertsServiceImpl implements ICertService {
             throw new BaseException(IResponseMessage.RESOURCE_NOT_FOUND, localizer.getMessage(IResponseMessage.RESOURCE_NOT_FOUND, null), ResponseCode.RESOURCE_NOT_FOUND.getCode());
         }
         return response;
+    }
+
+    private String getJsonSignedUrl(String jsonUrl) throws BaseException {
+        logger.info("getJsonSignedUrl: getting signedUrl for the url {}", jsonUrl);
+        String signedJsonUrl = null;
+        try {
+            Map<String, Object> certReqMap = new HashMap<>();
+            Map<String, String> requestMap = new HashMap<>();
+            requestMap.put(JsonKeys.PDF_URL, jsonUrl);
+            certReqMap.put(JsonKeys.REQUEST, requestMap);
+            String requestBody = requestMapper.writeValueAsString(certReqMap);
+            logger.info("getJsonSignedUrl:request body found.");
+            String apiToCall = CertVars.getSERVICE_BASE_URL().concat(CertVars.getDOWNLOAD_URI());
+            logger.info("getJsonSignedUrl:complete url found: {}", apiToCall);
+            Future<HttpResponse<JsonNode>> responseFuture = CertificateUtil.makeAsyncPostCall(apiToCall, requestBody, headerMap);
+            HttpResponse<JsonNode> jsonResponse = responseFuture.get();
+            if (jsonResponse != null && jsonResponse.getStatus() == HttpStatus.SC_OK) {
+                signedJsonUrl = jsonResponse.getBody().getObject().getJSONObject(JsonKeys.RESULT).getString(JsonKeys.SIGNED_URL);
+            }
+        } catch (Exception e) {
+            logger.error("getJsonSignedUrl:exception occurred: {} {}", e.getMessage(), e);
+            throw new BaseException(IResponseMessage.INTERNAL_ERROR, getLocalizedMessage(IResponseMessage.INTERNAL_ERROR, null), ResponseCode.SERVER_ERROR.getCode());
+        }
+        return signedJsonUrl;
+    }
+
+    private String getPrintUri(String signedJsonUrl) throws BaseException {
+        String printUri;
+        try {
+            URL url = new URL(signedJsonUrl);
+            String data = IOUtils.toString(url, StandardCharsets.UTF_8);
+            Map<String, Object> certificate = requestMapper.readValue(data, new TypeReference<Map<String, Object>>() {});
+            printUri = (String) certificate.get(JsonKeys.PRINT_URI);
+        } catch (IOException e) {
+            logger.error("getPrintUri:exception occurred {} {}", e.getMessage(), e);
+            throw new BaseException(IResponseMessage.INTERNAL_ERROR, getLocalizedMessage(e.getLocalizedMessage(), null), ResponseCode.SERVER_ERROR.getCode());
+        }
+        return printUri;
     }
 
     @Override

--- a/all-actors/src/main/java/org/sunbird/serviceimpl/CertsServiceImpl.java
+++ b/all-actors/src/main/java/org/sunbird/serviceimpl/CertsServiceImpl.java
@@ -230,12 +230,13 @@ public class CertsServiceImpl implements ICertService {
                 //view of svg which is of size 640kb ,it  is a part of cert data, which caused increase in cassandra disk space. Due to this issue now we decided that Cert-service shall upload the JSON (including the printURI) to the storage.
                 //So now the jsonUrl will not be empty. When a download is needed, cert-registry shall get a signed url to the json url and stream only the printURI portion as expected for SVG certificates.
                 if (StringUtils.isEmpty(jsonUrl)) {
+                    logger.info("getJsonSignedUrl: jsonUrl is empty , print uri is present in data object");
                     Map<String, Object> certificate = requestMapper.readValue((String) certInfo.get(JsonKeys.DATA), new TypeReference<Map<String, Object>>() {});
                     printUri = (String) certificate.get(JsonKeys.PRINT_URI);
                 } else {
                     Request req = new Request();
                     req.put(JsonKeys.PDF_URL,certInfo.get(JsonKeys.JSON_URL));
-                    logger.info("getJsonSignedUrl: getting signedUrl for the url {}", certInfo.get(JsonKeys.JSON_URL));
+                    logger.info("getJsonSignedUrl: getting signedUrl for the json url {}", certInfo.get(JsonKeys.JSON_URL));
                     Response downloadRes = download(req);
                     String signedJsonUrl = (String) downloadRes.getResult().get(JsonKeys.SIGNED_URL);
                     printUri = getPrintUri(signedJsonUrl);

--- a/all-actors/src/main/java/org/sunbird/serviceimpl/CertsServiceImpl.java
+++ b/all-actors/src/main/java/org/sunbird/serviceimpl/CertsServiceImpl.java
@@ -226,9 +226,7 @@ public class CertsServiceImpl implements ICertService {
             try {
                 String jsonUrl = (String) certInfo.get(JsonKeys.JSON_URL);
                 String printUri;
-                //decided not to upload cert json into the cloud (1.5.0) as it was already storing in cassandra in the column data( jsonUrl was null), but due to the materialised
-                //view of svg which is of size 640kb ,it  is a part of cert data, which caused increase in cassandra disk space. Due to this issue now we decided that Cert-service shall upload the JSON (including the printURI) to the storage.
-                //So now the jsonUrl will not be empty. When a download is needed, cert-registry shall get a signed url to the json url and stream only the printURI portion as expected for SVG certificates.
+                //in-some cases jsonUrl was not filled(1.5.0 prior to fix), in some-cases jsonUrl is filled (because of svg content growth,now we are uploading cert to cloud)
                 if (StringUtils.isEmpty(jsonUrl)) {
                     logger.info("getJsonSignedUrl: jsonUrl is empty , print uri is present in data object");
                     Map<String, Object> certificate = requestMapper.readValue((String) certInfo.get(JsonKeys.DATA), new TypeReference<Map<String, Object>>() {});

--- a/all-actors/src/main/java/org/sunbird/serviceimpl/CertsServiceImpl.java
+++ b/all-actors/src/main/java/org/sunbird/serviceimpl/CertsServiceImpl.java
@@ -226,7 +226,7 @@ public class CertsServiceImpl implements ICertService {
             try {
                 String jsonUrl = (String) certInfo.get(JsonKeys.JSON_URL);
                 String printUri;
-                //in-some cases jsonUrl was not filled(1.5.0 prior to fix), in some-cases jsonUrl is filled (because of svg content growth,now we are uploading cert to cloud)
+                //in-some cases jsonUrl was not filled(1.5.0 prior to fix), After fix jsonUrl is being filled (because of svg content growth,now we are uploading cert to cloud)
                 if (StringUtils.isEmpty(jsonUrl)) {
                     logger.info("getJsonSignedUrl: jsonUrl is empty , print uri is present in data object");
                     Map<String, Object> certificate = requestMapper.readValue((String) certInfo.get(JsonKeys.DATA), new TypeReference<Map<String, Object>>() {});

--- a/all-actors/src/test/java/org/sunbird/actor/CertificationActorTest.java
+++ b/all-actors/src/test/java/org/sunbird/actor/CertificationActorTest.java
@@ -8,6 +8,7 @@ import akka.testkit.javadsl.TestKit;
 import com.google.common.collect.Lists;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.JsonNode;
+import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpStatus;
 import org.json.JSONObject;
 import org.junit.Assert;
@@ -38,6 +39,8 @@ import org.sunbird.serviceimpl.CertsServiceImpl;
 import org.sunbird.utilities.CertificateUtil;
 import scala.concurrent.duration.Duration;
 
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -58,7 +61,9 @@ import static org.powermock.api.mockito.PowerMockito.when;
         ElasticSearchService.class,
         CassandraOperation.class,
         CassandraDACImpl.class,
-        CertVars.class})
+        CertVars.class,
+        IOUtils.class,
+        URL.class})
 @PowerMockIgnore("javax.management.*")
 public class CertificationActorTest {
 
@@ -108,8 +113,8 @@ public class CertificationActorTest {
         when(object.getJSONObject(JsonKeys.HITS)).thenReturn(jsonObject);
         object2 = Mockito.mock(JSONObject.class);
         when(object.getJSONObject(JsonKeys.RESULT)).thenReturn(object2);
-
-        when(object2.getString(JsonKeys.SIGNED_URL)).thenReturn("signed_url");
+        String signedUrl ="http://localhost:9000/dev-e-credentials/0125450863553740809/4d88c2e4-212b-4c00-aa83-1cd3fde7b447.json";
+        when(object2.getString(JsonKeys.SIGNED_URL)).thenReturn(signedUrl);
         when(object2.get(JsonKeys.RESPONSE)).thenReturn(map);
         when(certsService.download(Mockito.any(Request.class))).thenReturn(getValidateCertResponse());
         when(CertificateUtil.getCertificate(Mockito.anyString())).thenReturn(map);
@@ -121,6 +126,10 @@ public class CertificationActorTest {
         when(certsService.verify(Mockito.any(Request.class))).thenReturn(getValidateCertResponse());
         when(CertificateUtil.getCertificate(Mockito.anyString())).thenReturn(map);
         when(CertificateUtil.getCertRecordByID(Mockito.anyString())).thenReturn(getCertReadResponse());
+        URL mockedURL = PowerMockito.mock(URL.class);
+        PowerMockito.whenNew(URL.class).withArguments(signedUrl).thenReturn(mockedURL);
+        PowerMockito.mockStatic(IOUtils.class);
+        when(IOUtils.toString(mockedURL, StandardCharsets.UTF_8)).thenReturn("{\"id\":\"http://localhost:8080/_schemas/Certificate/d5a28280-98ac-4294-a508-21075dc7d475\",\"type\":[\"Assertion\",\"Extension\",\"extensions:CertificateExtension\"],\"issuedOn\":\"2019-08-31T12:52:25Z\",\"recipient\":{\"identity\":\"ntptest103\",\"type\":[\"phone\"],\"hashed\":false,\"name\":\"Aishwarya\",\"@context\":\"http://localhost:8080/_schemas/context.json\"},\"badge\":{\"id\":\"http://localhost:8080/_schemas/Badge.json\",\"type\":[\"BadgeClass\"],\"name\":\"Sunbird installation\",\"description\":\"Certificate of Appreciation in National Level ITI Grading\",\"image\":\"https://certs.example.gov/o/dgt/HJ5327VB1247G\",\"criteria\":{\"type\":[\"Criteria\"],\"id\":\"http://localhost:8080/_schemas/Certificate/d5a28280-98ac-4294-a508-21075dc7d475\",\"narrative\":\"For exhibiting outstanding performance\"},\"issuer\":{\"context\":\"http://localhost:8080/_schemas/context.json\",\"id\":\"http://localhost:8080/_schemas/Issuer.json\",\"type\":[\"Issuer\"],\"name\":\"NIIT\"},\"@context\":\"http://localhost:8080/_schemas/context.json\"},\"expires\":\"2019-09-30T12:52:25Z\",\"verification\":{\"type\":[\"SignedBadge\"],\"creator\":\"http://localhost:8080/_schemas/publicKey.json\"},\"revoked\":false,\"validFrom\":\"2019-06-21\",\"@context\":\"http://localhost:8080/_schemas/context.json\",\"printUri\":\"data:image/svg+xml,%3Csvg ....\"}");
     }
 
     public static void tearDown() throws Exception {
@@ -237,6 +246,7 @@ public class CertificationActorTest {
         responseMap.put(JsonKeys.RELATED, "{\"type\":\"course completion certificate prad\",\"batchId\":\"0130589602973368326\",\"courseId\":\"do_11305895730108006411643\"}");
         responseMap.put(JsonKeys.RECIPIENT, "{\"name\":\"Test user\",\"email\":null,\"phone\":null,\"id\":null,\"type\":\"individual\"}");
         responseMap.put(JsonKeys.ACCESS_CODE, "access_code");
+        responseMap.put(JsonKeys.JSON_URL, "http://localhost:9000/certs/0125450863553740809/0ec760f3-a82e-4d3a-b97b-7be2e3a8298f.json");
         Response response = new Response();
         response.put(JsonKeys.RESPONSE, Lists.newArrayList(responseMap));
         return response;

--- a/sb-es-utils/src/main/resources/mappings/certreg-mapping.json
+++ b/sb-es-utils/src/main/resources/mappings/certreg-mapping.json
@@ -41,6 +41,9 @@
       "search_analyzer": "cs_search_analyzer",
       "fielddata": true
     },
+    "data": {
+      "type": "object"
+    },
     "id": {
       "type": "text",
       "fields": {

--- a/service/app/validators/CertAddRequestValidator.java
+++ b/service/app/validators/CertAddRequestValidator.java
@@ -34,7 +34,7 @@ public class CertAddRequestValidator implements IRequestValidator {
     public void validate(Request request) throws BaseException {
         this.request=request;
         if (((String) request.getContext().get(JsonKeys.VERSION)).equalsIgnoreCase(JsonKeys.VERSION_2)) {
-            mandatoryParamsList = Lists.newArrayList(JsonKeys.ID, JsonKeys.ACCESS_CODE);
+            mandatoryParamsList = Lists.newArrayList(JsonKeys.ID, JsonKeys.ACCESS_CODE, JsonKeys.JSON_URL);
         } else {
             mandatoryParamsList = Lists.newArrayList(JsonKeys.ID, JsonKeys.ACCESS_CODE, JsonKeys.PDF_URL);
         }

--- a/service/test/controllers/CertificateControllerTest.java
+++ b/service/test/controllers/CertificateControllerTest.java
@@ -173,6 +173,7 @@ public class CertificateControllerTest extends BaseApplicationTest {
             innerMap.put("id", "id5dd4");
         }
         innerMap.put("accessCode", "EANAB13");
+        innerMap.put("jsonUrl", "http://localhost:9000/certs/0125450863553740809/d7707145-68bc-4005-8b05-d72c959e7886.json  dfrte fits");
         Map<String,Object> jsonData = new HashMap<>();
         jsonData.put("id", "http://localhost:8080/_schemas/Certificate/d5a28280-98ac-4294-a508-21075dc7d475");
         jsonData.put("type",new String[]{"Assertion","Extension"});


### PR DESCRIPTION
1) Download V2:  get a signed  Json URL by calling cert-service and read certJson to get the  printURI portion 
2) add certificate data without printUri to Cassandra 
3) Continue to index the data{} portion of ES without the printURI 