### PR TITLE
SB-29887 adding headers to request

### DIFF
--- a/all-actors/src/main/java/org/sunbird/BaseActor.java
+++ b/all-actors/src/main/java/org/sunbird/BaseActor.java
@@ -9,10 +9,7 @@ import org.sunbird.message.ResponseCode;
 import org.sunbird.request.Request;
 
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 
 /**
  * @author Amit Kumar
@@ -29,9 +26,13 @@ public abstract class BaseActor extends UntypedAbstractActor {
             Request request = (Request) message;
             Map<String, Object> trace = new HashMap<>();
             if (request.getHeaders().containsKey(JsonKeys.REQUEST_MESSAGE_ID)) {
-                ArrayList<String> requestIds =
-                        (ArrayList<String>) request.getHeaders().get(JsonKeys.REQUEST_MESSAGE_ID);
-                trace.put(JsonKeys.REQUEST_MESSAGE_ID, requestIds.get(0));
+                if(request.getHeaders().get(JsonKeys.REQUEST_MESSAGE_ID) instanceof String) {
+                    trace.put(JsonKeys.REQUEST_MESSAGE_ID, request.getHeaders().get(JsonKeys.REQUEST_MESSAGE_ID));
+                } else {
+                    ArrayList<String> requestIds =
+                      (ArrayList<String>) request.getHeaders().get(JsonKeys.REQUEST_MESSAGE_ID);
+                    trace.put(JsonKeys.REQUEST_MESSAGE_ID, requestIds.get(0));
+                }
                 logger.setMDC(trace);
                 // set mdc for non actors
                 new BaseLogger().setReqId(logger.getMDC());

--- a/service/app/controllers/BaseController.java
+++ b/service/app/controllers/BaseController.java
@@ -1,5 +1,9 @@
 package controllers;
 
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
@@ -8,6 +12,7 @@ import akka.actor.ActorRef;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sunbird.BaseException;
@@ -20,6 +25,7 @@ import org.sunbird.response.Response;
 import play.libs.Json;
 import play.libs.concurrent.HttpExecutionContext;
 import play.mvc.Controller;
+import play.mvc.Http;
 import play.mvc.Result;
 import play.mvc.Results;
 import utils.RequestMapper;
@@ -101,6 +107,10 @@ public class BaseController extends Controller {
             if (req.body() != null && req.body().asJson() != null) {
                 request = (Request) RequestMapper.mapRequest(req, Request.class);
             }
+            if (req.getHeaders() != null && request.getHeaders() != null) {
+                Map<String, Object> map = getAllRequestHeaders(req);
+                request.setHeaders(map);
+            }
             if (validatorFunction != null) {
                 validatorFunction.apply(request);
             }
@@ -119,5 +129,16 @@ public class BaseController extends Controller {
                             + ", So play server will not allow any new request.");
             throw new BaseException(IResponseMessage.SERVICE_UNAVAILABLE, IResponseMessage.SERVICE_UNAVAILABLE, ResponseCode.SERVICE_UNAVAILABLE.getCode());
         }
+    }
+    
+    public Map<String, Object> getAllRequestHeaders(Http.Request request) {
+        Map<String, Object> map = new HashMap<>();
+        Map<String, List<String>> headers = request.getHeaders().toMap();
+        Iterator<Map.Entry<String, List<String>>> itr = headers.entrySet().iterator();
+        while (itr.hasNext()) {
+            Map.Entry<String, List<String>> entry = itr.next();
+            map.put(entry.getKey(), entry.getValue().get(0));
+        }
+        return map;
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-29887" title="SB-29887" target="_blank"><img alt="Defect" src="https://project-sunbird.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10304?size=medium" />SB-29887</a>  Mobile App: In backward builds(4.8.194 and 4.7.180) for custodian user Learner passbook is not displayed. Also Certificate is not shown for new courses in My Learning section
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Java-11, play2-2.7.2
* Hardware versions: 2 CPU/ 4GB RAM

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
