### PR TITLE
Issue #SBCOSS-00: Create Github actions to publish docker image to GHCR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,74 @@
+name: Build and Deploy
+
+on:
+    push:
+      tags:
+        - '*'
+
+jobs:
+  ghcr-build-and-deploy:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    env:
+      REGISTRY: ghcr.io
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
+      - name: Cache Maven packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Build and run test cases
+        run: mvn clean install -DskipTests
+
+      - name: Package build artifact (Play dist)
+        run: mvn -f service/pom.xml play2:dist
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: cert-service-dist
+          path: |
+            service/target/service-*-dist.zip
+      - name: Extract image tag details
+        id: image_vars
+        run: |
+          REPO_LOWER=$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          TAG_LOWER=$(echo "${GITHUB_REF_NAME}" | tr '[:upper:]' '[:lower:]')
+          IMAGE_NAME=${{ env.REGISTRY }}/${REPO_LOWER}
+          IMAGE_TAG=${TAG_LOWER}_${SHORT_SHA}_${GITHUB_RUN_NUMBER}
+          echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+      - name: Log in to GitHub Container Registry (GHCR)
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image to GHCR
+        uses: docker/build-push-action@v4
+        with:
+          context: ./service/target
+          file: ./Dockerfile
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - name: Build and run test cases
+      - name: Build
         run: mvn clean install -DskipTests
 
       - name: Package build artifact (Play dist)


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to the `certificate-registry` repository.

**Build and Deploy (`build.yml`):**  
Triggers when a Git tag is pushed.  
Builds the project, packages the artifact, builds a Docker image, and pushes it to GitHub Container Registry (GHCR).

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a GitHub Actions workflow to automate the build and deployment of a Docker image to the GitHub Container Registry (GHCR) upon tagging any commit.

### Why are these changes being made?

Automating the build and deployment process ensures consistency, reduces manual errors, and saves developer time by automatically publishing Docker images to GHCR when a tag is pushed. This approach leverages GitHub's native CI/CD capabilities and integrates well with existing workflows.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->